### PR TITLE
Fix #2: Replace Anthropic API Key authentication with Claude CLI authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ SLACK_APP_TOKEN=xapp-your-app-token
 SLACK_SIGNING_SECRET=your-signing-secret
 
 # Claude Code Configuration
-ANTHROPIC_API_KEY=your-anthropic-api-key
+# The bot now uses Claude CLI authentication instead of API key
+# Make sure to run 'claude auth' before starting the bot
 
 # Working Directory Configuration
 # Base directory for relative paths (e.g., /Users/username/Code/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Currently, no test framework or linting is configured. When implementing tests o
 1. **Slack Events** → `slack-handler.ts` receives and processes messages
 2. **Session Management** → `claude-handler.ts` maintains per-conversation Claude Code sessions
 3. **Working Directory** → `working-directory-manager.ts` resolves project paths
-4. **Tool Execution** → Claude Code SDK executes tools with proper context
+4. **Tool Execution** → Claude CLI executes tools with proper context (no longer uses SDK)
 5. **Response Streaming** → Real-time updates sent back to Slack
 
 ### Session Architecture
@@ -88,6 +88,13 @@ Currently, no test framework or linting is configured. When implementing tests o
 - Lazy session initialization
 - Efficient message batching
 - Smart update detection in todo manager
+
+### Authentication
+- **Claude CLI**: Uses local Claude CLI authentication instead of API keys
+- **No API Key Required**: Leverages existing `claude auth` credentials
+- **Process Spawning**: Each query spawns a new Claude CLI process
+- **User Context**: Runs with the local user's Claude authentication
+- **Auth Check on Startup**: Verifies CLI authentication before starting
 
 ## Working with This Codebase
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Slack bot that integrates with Claude Code SDK to provide AI-powered coding as
 
 - Node.js 18+ installed
 - A Slack workspace where you can install apps
-- Claude Code
+- Claude Code CLI authenticated (`claude auth`)
 
 ## Setup
 
@@ -27,7 +27,17 @@ cd claude-code-slack
 npm install
 ```
 
-### 2. Create Slack App
+### 2. Authenticate Claude CLI
+
+The bot uses Claude CLI authentication. Make sure you're authenticated before running the bot:
+
+```bash
+claude auth
+```
+
+Follow the prompts to authenticate with your Claude account.
+
+### 3. Create Slack App
 
 #### Option A: Using App Manifest (Recommended)
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click "Create New App"
@@ -41,7 +51,7 @@ npm install
 2. Choose "From scratch" and give your app a name
 3. Select the workspace where you want to install it
 
-### 3. Configure Slack App
+### 4. Configure Slack App
 
 After creating the app (either method), you need to:
 
@@ -56,7 +66,7 @@ After creating the app (either method), you need to:
 1. Go to "Basic Information"
 2. Copy the "Signing Secret"
 
-### 4. Configure Environment
+### 5. Configure Environment
 
 Copy `.env.example` to `.env` and fill in your credentials:
 
@@ -72,14 +82,15 @@ SLACK_APP_TOKEN=xapp-your-app-token
 SLACK_SIGNING_SECRET=your-signing-secret
 
 # Claude Code Configuration
-# This is only needed if you don't use a Claude subscription
+# The bot now uses Claude CLI authentication instead of API key
+# Make sure to run 'claude auth' before starting the bot
 
-# ANTHROPIC_API_KEY=your-anthropic-api-key
+# Optional: Use third-party providers
 # CLAUDE_CODE_USE_BEDROCK=1
 # CLAUDE_CODE_USE_VERTEX=1
 ```
 
-### 5. Run the Bot
+### 6. Run the Bot
 
 ```bash
 # Development mode (with auto-reload)
@@ -281,7 +292,7 @@ src/
 4. Check Slack app permissions are configured correctly
 
 ### Authentication errors
-1. Verify your Anthropic API key is valid
+1. Verify Claude CLI is authenticated (run `claude auth`)
 2. Check Slack tokens haven't expired
 3. Ensure Socket Mode is enabled
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "^1.0.35",
     "@modelcontextprotocol/sdk": "^1.13.2",
     "@slack/bolt": "^4.4.0",
     "@types/node-fetch": "^2.6.12",

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,6 @@ export const config = {
     appToken: process.env.SLACK_APP_TOKEN!,
     signingSecret: process.env.SLACK_SIGNING_SECRET!,
   },
-  anthropic: {
-    apiKey: process.env.ANTHROPIC_API_KEY!,
-  },
   claude: {
     useBedrock: process.env.CLAUDE_CODE_USE_BEDROCK === '1',
     useVertex: process.env.CLAUDE_CODE_USE_VERTEX === '1',

--- a/src/slack-handler.ts
+++ b/src/slack-handler.ts
@@ -1,6 +1,5 @@
 import { App } from '@slack/bolt';
-import { ClaudeHandler } from './claude-handler';
-import { SDKMessage } from '@anthropic-ai/claude-code';
+import { ClaudeHandler, SDKMessage } from './claude-handler';
 import { Logger } from './logger';
 import { WorkingDirectoryManager } from './working-directory-manager';
 import { FileHandler, ProcessedFile } from './file-handler';


### PR DESCRIPTION
## Summary
This PR replaces the Anthropic API Key authentication with Claude CLI authentication, implementing Option 1 (Direct CLI Invocation) from the specification in issue #2.

## Changes
- 🔄 Replace SDK `query()` function with direct CLI process spawning in `claude-handler.ts`
- 🗑️ Remove `ANTHROPIC_API_KEY` from configuration and environment files
- ✅ Add Claude CLI authentication check on startup
- 📦 Remove `@anthropic-ai/claude-code` dependency
- 📝 Update documentation to reflect CLI authentication

## Implementation Details
The bot now spawns the Claude CLI directly instead of using the SDK, which:
- Maintains all existing functionality (sessions, MCP servers, permissions)
- Uses streaming JSON output format for real-time responses
- Handles process lifecycle and error management
- Verifies CLI authentication before starting

## Benefits
- ✅ Consistent authentication across all repository tools
- ✅ No API key management required
- ✅ Better security (no exposed API keys)
- ✅ Direct control over CLI arguments

## Test plan
- [ ] Run `npm install` to update dependencies
- [ ] Run `claude auth` to ensure CLI is authenticated
- [ ] Run `npm run build` to verify TypeScript compilation
- [ ] Run `npm start` and test bot functionality
- [ ] Test Slack interactions (DMs, threads, MCP tools)
- [ ] Verify session management works correctly
- [ ] Check error handling for unauthenticated CLI

## Migration Guide
For existing users:
1. Run `claude auth` to authenticate CLI
2. Remove `ANTHROPIC_API_KEY` from `.env`
3. Run `npm install` to update dependencies
4. Restart the bot

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)